### PR TITLE
Workaround to set the CoreProperties relationship ID

### DIFF
--- a/package.go
+++ b/package.go
@@ -146,7 +146,7 @@ func (c *contentTypes) ensureOverridesMap() {
 	}
 }
 
-// Add needs a valid content type, else the behaviour is undefined
+// Add needs a valid content type, else the behavior is undefined
 func (c *contentTypes) add(partName, contentType string) error {
 	// Process descrived in ISO/IEC 29500-2 §10.1.2.3
 	t, params, _ := mime.ParseMediaType(contentType)
@@ -253,7 +253,8 @@ func (s w3CDateTime) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // CoreProperties enable users to get and set well-known and common sets of property metadata within packages.
 type CoreProperties struct {
-	PartName       string // Won't be writed to the package, only used to indicate the location of the CoreProperties part. If empty the default location is "/props/core.xml".
+	PartName       string // Won't be written to the package, only used to indicate the location of the CoreProperties part. If empty the default location is "/props/core.xml".
+	RelationshipID string // Won't be written to the package, only used to indicate the relationship ID for target "/props/core.xml".
 	Category       string // A categorization of the content of this package.
 	ContentStatus  string // The status of the content.
 	Created        string // Date of creation of the resource.

--- a/package_test.go
+++ b/package_test.go
@@ -109,7 +109,7 @@ func TestCoreProperties_encode(t *testing.T) {
     <category>A</category>
     <lastPrinted xsi:type="dcterms:W3CDTF">b</lastPrinted>
 `), false},
-		{"all", &CoreProperties{"partName", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o"},
+		{"all", &CoreProperties{"partName", "rId1", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o"},
 			buildCoreString(`
     <category>a</category>
     <contentStatus>b</contentStatus>

--- a/writer.go
+++ b/writer.go
@@ -115,7 +115,8 @@ func (w *Writer) createCoreProperties() error {
 	if err != nil {
 		return err
 	}
-	w.Relationships = append(w.Relationships, &Relationship{"", corePropsRel, part.Name, ModeInternal})
+	w.Relationships = append(w.Relationships,
+		&Relationship{w.Properties.PartName, corePropsRel, part.Name, ModeInternal})
 	return w.Properties.encode(cw)
 }
 

--- a/writer.go
+++ b/writer.go
@@ -116,7 +116,7 @@ func (w *Writer) createCoreProperties() error {
 		return err
 	}
 	w.Relationships = append(w.Relationships,
-		&Relationship{w.Properties.PartName, corePropsRel, part.Name, ModeInternal})
+		&Relationship{w.Properties.RelationshipID, corePropsRel, part.Name, ModeInternal})
 	return w.Properties.encode(cw)
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -53,6 +53,7 @@ func TestWriter_Close(t *testing.T) {
 		{"withDuplicatedRels", &Writer{p: pRel, w: zip.NewWriter(&bytes.Buffer{}), Properties: CoreProperties{Title: "Song"}, rnd: fakeRand()}, true},
 		{"withCoreProps", &Writer{p: newPackage(), w: zip.NewWriter(&bytes.Buffer{}), Properties: CoreProperties{Title: "Song"}, rnd: fakeRand()}, false},
 		{"withCorePropsWithName", &Writer{p: newPackage(), w: zip.NewWriter(&bytes.Buffer{}), Properties: CoreProperties{Title: "Song", PartName: "/props.xml"}, rnd: fakeRand()}, false},
+		{"withCorePropsWithNameAndId", &Writer{p: newPackage(), w: zip.NewWriter(&bytes.Buffer{}), Properties: CoreProperties{Title: "Song", PartName: "/docProps/props.xml", RelationshipID: "rId1"}, rnd: fakeRand()}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
New CoreProperties member: RelationshipID. Like PartName, it is not serialized in the XML. 

Microsoft Office requires the relationship ID values honoring the pattern rIdNNN where NNN is a positive number.
This change will allow users to predefine the ID to bypass 