### PR TITLE
Add NewWriterFromReader

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -59,3 +59,34 @@ func ExampleReader() {
 		fmt.Println()
 	}
 }
+
+func ExampleNewWriterFromReader() {
+	r, err := opc.OpenReader("testdata/component.3mf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer r.Close()
+
+	buf := new(bytes.Buffer)
+	w, err := opc.NewWriterFromReader(buf, r.Reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+	name := opc.NormalizePartName("docs\\readme.txt")
+	part, err := w.Create(name, "text/plain")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Write content to the part.
+	_, err = part.Write([]byte("This archive contains some text files."))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Make sure to check the error on Close.
+	if err := w.Close(); err != nil {
+		log.Fatal(err)
+	}
+}
+

--- a/writer.go
+++ b/writer.go
@@ -53,7 +53,7 @@ func NewWriter(w io.Writer) *Writer {
 // and with its content initialized with r.
 // Parts comming from r cannot be modified but new parts can be appended
 // and package core properties and relationships can be updated.
-func NewWriterFromReader(w io.Writer, r Reader) (*Writer, error) {
+func NewWriterFromReader(w io.Writer, r *Reader) (*Writer, error) {
 	ow := NewWriter(w)
 	for _, p := range r.Files {
 		pw, err := ow.CreatePart(p.Part, CompressionNormal)
@@ -67,7 +67,10 @@ func NewWriterFromReader(w io.Writer, r Reader) (*Writer, error) {
 		io.Copy(pw, rc)
 	}
 	ow.Properties = r.Properties
-	copy(ow.Relationships, r.Relationships)
+	ow.Relationships = make([]*Relationship, len(r.Relationships))
+	for i, rel := range r.Relationships {
+		ow.Relationships[i] = &(*rel)
+	}
 	return ow, nil
 }
 

--- a/writer.go
+++ b/writer.go
@@ -64,7 +64,11 @@ func NewWriterFromReader(w io.Writer, r *Reader) (*Writer, error) {
 		if err != nil {
 			return nil, err
 		}
-		io.Copy(pw, rc)
+		_, err = io.Copy(pw, rc)
+		rc.Close()
+		if err != nil {
+			return nil, err
+		}
 	}
 	ow.Properties = r.Properties
 	ow.Relationships = make([]*Relationship, len(r.Relationships))

--- a/writer_test.go
+++ b/writer_test.go
@@ -194,3 +194,24 @@ func TestWriter_createLastPartRelationships(t *testing.T) {
 		})
 	}
 }
+
+func TestNewWriterFromReader(t *testing.T) {
+	r, err := OpenReader("testdata/office.docx")
+	if err != nil {
+		t.Fatalf("failed to open test file: %v", err)
+	}
+	var buf bytes.Buffer
+	w, err := NewWriterFromReader(&buf, r.Reader)
+	if err != nil {
+		t.Fatalf("NewWriterFromReader() error: %v", err)
+	}
+	if w.Properties != r.Properties {
+		t.Error("NewWriterFromReader() haven't copied core properties")
+	}
+	if len(w.Relationships) != len(r.Relationships) {
+		t.Error("NewWriterFromReader() haven't copied package relationships")
+	}
+	if err = w.Close(); err != nil {
+		t.Errorf("NewWriterFromReader() created package that cannot be closed: %v", err)
+	}
+}


### PR DESCRIPTION
`NewWriterFromReader` is a helper function that created a new `Writer` with the content of a `Reader`. This facilitate the task of modifying core properties and package relationships and appending parts to a package.