### PR TITLE
Fix escaping in part name normalization

### DIFF
--- a/part.go
+++ b/part.go
@@ -193,8 +193,9 @@ func escape(s string) string {
 				t[j+2] = '5'
 				j += 3
 			} else {
-				t[j], t[j+1], t[j+3] = '%', s[i+1], s[i+2]
+				t[j], t[j+1], t[j+2] = '%', s[i+1], s[i+2]
 				j += 3
+				i += 2
 			}
 		default:
 			c := s[i]

--- a/part_test.go
+++ b/part_test.go
@@ -33,6 +33,7 @@ func TestNormalizePartName(t *testing.T) {
 		{"percentSign2", args{"/docs%25/%41.xml"}, "/docs%25/A.xml"},
 		{"percentSignEnd", args{"/docs/a.%"}, "/docs/a.%25"},
 		{"pre-encoded", args{"/%3Aa.xml"}, "/%3Aa.xml"},
+		{"pre-encodedMixedWithNecessaryEscaped", args{"/%28a a.xml"}, "/%28a%20a.xml"},
 		{"chinese", args{"/传/傳.xml"}, "/%E4%BC%A0/%E5%82%B3.xml"},
 		{"fromSpec1", args{"/a/b.xml"}, "/a/b.xml"},
 		{"fromSpec2", args{"/a/ц.xml"}, "/a/%D1%86.xml"},


### PR DESCRIPTION
The iteration of reading the input string of the function was problematic. When finding a pre-encoded character, for instance `%28` (which is an open bracket - `'('`), all three characters were written in the destination string, but the reading of the input string continued with the character after `'%'`, which was `'2'`. The correct behavior is for the reading to continue with the character after `'8'`.

The writing in the destination also had a bug. Instead of writing the 3 characters (`'%'`, `'2'` and `'8'`) one after another, the first two were written correctly, namely at position `j` and `j+1` in the destination string, but the third character was written at `j+3` instead of at `j+2`.

This problem had not appeared before in the tests in `part_test.go`, because there was no test case that has both a pre-encoded character and a character to be encoded. When there are no characters to be encoded in the input string, the string is returned as it was given in the input. Such a test case would have resulted in an index out of range error.