### PR TITLE
Fix TestPart_validate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.20.x, 1.21.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/part_test.go
+++ b/part_test.go
@@ -92,7 +92,7 @@ func TestPart_validate(t *testing.T) {
 		{"mediaLinearEnd", &Part{"/a.txt", "TEXT/html; charset=ISO-8859-4;q=2/t", nil}, true},
 		{"invalidMediaParams", &Part{"/a.txt", "TEXT/html; charset=ISO-8859-4 q=2", nil}, true},
 		{"mediaParamNoName", &Part{"/a.txt", "TEXT/html; =ISO-8859-4", nil}, true},
-		{"duplicateParamName", &Part{"/a.txt", "TEXT/html; charset=ISO-8859-4; charset=ISO-8859-4", nil}, true},
+		{"duplicatedMedia", &Part{"/a.txt", "TEXT/html; charset=ISO-8859-4; charset=UTF-8", nil}, true},
 		{"linearSpace", &Part{"/a.txt", "TEXT/t/html; charset=ISO-8859-4;q=2", nil}, true},
 		{"whiteSpace", &Part{"/a.txt", "TEXT /html; charset=ISO-8859-4;q=2", nil}, true},
 		{"noSlash", &Part{"/a.txt", "application", nil}, true},


### PR DESCRIPTION
Since go1.20, `mime.ParseMediaType` doesn't consider duplicated media types as errors (see [CL 363094](https://go-review.googlesource.com/c/go/+/363094)). This broke `TestPart_validate` expectations.